### PR TITLE
Add unit test for theme colors

### DIFF
--- a/hooks/useThemeColor.ts
+++ b/hooks/useThemeColor.ts
@@ -3,19 +3,22 @@
  * https://docs.expo.dev/guides/color-schemes/
  */
 
-import { Colors } from '@/constants/Colors';
-import { useColorScheme } from '@/hooks/useColorScheme';
+import { Colors } from '../constants/Colors.js';
+import { useColorScheme } from './useColorScheme.js';
+
+export function getThemeColor(
+  theme: 'light' | 'dark',
+  props: { light?: string; dark?: string },
+  colorName: keyof typeof Colors.light & keyof typeof Colors.dark
+) {
+  const colorFromProps = props[theme];
+  return colorFromProps ?? Colors[theme][colorName];
+}
 
 export function useThemeColor(
   props: { light?: string; dark?: string },
   colorName: keyof typeof Colors.light & keyof typeof Colors.dark
 ) {
   const theme = useColorScheme() ?? 'light';
-  const colorFromProps = props[theme];
-
-  if (colorFromProps) {
-    return colorFromProps;
-  } else {
-    return Colors[theme][colorName];
-  }
+  return getThemeColor(theme, props, colorName);
 }

--- a/tests/colors.test.ts
+++ b/tests/colors.test.ts
@@ -1,0 +1,8 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Colors } from '../constants/Colors.js';
+
+test('light theme background color', () => {
+  assert.strictEqual(Colors.light.background, '#fff');
+});
+


### PR DESCRIPTION
## Summary
- add `getThemeColor` helper and expose it
- implement a basic `Colors` test using Node's test runner

## Testing
- `npx tsc --outDir build --noEmit false`
- `node --test build/tests/colors.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6863909a8d7883328feea1896ea5eea3